### PR TITLE
fix: FE 로컬 서버에서 API 서버 호스트주소 사용할 수 있게 사용(테스트 환경이므로 가능)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,8 @@ services:
       - .env.dev
     depends_on:
       - db  
-    restart: always  
+    network_mode: "host"
+    restart: always
 
   db:
     image: kyeong6/mysql_app:latest


### PR DESCRIPTION
<!--연관된 티켓 번호를 작성하세요. 예) #111-->
## 🎟️ Related Ticket: #16 

## ✏️ Description
<!--설명을 작성하세요.-->
- FE 로컬 서버에서 API 서버 호스트주소 사용할 수 있게 사용
## 🧩 How
<!-- 구현 방법을 작성하세요.-->
- docker-compose.yaml에 "network_mode=host" 설정
## ⚠️ PR 참고 사항
<!-- 참고 사항을 작성하세요.-->
- docker-compose.yaml 확인

## 📸 Screen Shot
<!-- 이미지를 첨부하세요.-->

## ✅ Test Check
<!--테스트 진행 상황을 체크하세요.-->
- [x] 테스트 작성 완료
- [ ] 테스트 확인 완료

## Etc.
<!--기타-->
